### PR TITLE
feat: 添加 info 页面来展示 Package 和测例信息

### DIFF
--- a/os-checks/components/InfoTestCases.vue
+++ b/os-checks/components/InfoTestCases.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <DataTable :value="data" showGridlines>
+
+    <Column field="idx" header="Idx" />
+    <Column field="binary_name" header="Binary Name" />
+    <Column field="kind" header="Kind" />
+    <Column field="test" header="Test Case" />
+
+  </DataTable>
+
+</template>
+
+<script setup lang="ts">
+import type { Test } from '~/shared/info';
+
+const { tests } = defineProps<{ tests: Test[] }>();
+
+const data = computed(() => {
+  let idx = 0;
+  return tests.map(test => {
+    return test.testcases.map(t => {
+      idx += 1;
+      return {
+        idx,
+        binary_name: test.binary_name,
+        kind: test.kind,
+        test: t,
+      }
+    })
+  }).flat();
+});
+</script>

--- a/os-checks/components/TopBar.vue
+++ b/os-checks/components/TopBar.vue
@@ -23,6 +23,10 @@
         <Button title="Github Workflows" icon="pi pi-bell" />
       </NuxtLink>
 
+      <NuxtLink to="/info">
+        <Button title="Package & Testcase Infomation" icon="pi pi-microchip" />
+      </NuxtLink>
+
     </div>
 
     <div class="topBarRight">

--- a/os-checks/pages/index.vue
+++ b/os-checks/pages/index.vue
@@ -147,13 +147,13 @@ const progressRatio = computed(() => {
 }
 
 .nav-link {
-  color: #336ad7;
+  color: var(--p-indigo-500);
   /* 统一的链接颜色 */
   text-decoration: none;
 }
 
 .nav-link.router-link-active {
-  color: #336ad7;
+  color: var(--p-indigo-500);
   /* 重置激活链接的颜色 */
 }
 

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
-    <DataTable :value="summaryTable" tableStyle="min-width: 50rem; margin: 10px 10px;" scrollable scrollHeight="800px"
-      showGridlines selectionMode="single" v-model:selection="selectedPkg" v-model:filters="filters"
-      :globalFilterFields="['user', 'repo', 'pkg', 'description', 'categories', 'os_categories']">
+    <DataTable :value="summaryTable" tableStyle="min-width: 50rem;" scrollable scrollHeight="800px" showGridlines
+      selectionMode="single" v-model:selection="selectedPkg" v-model:filters="filters"
+      :globalFilterFields="['user', 'repo', 'pkg', 'description', 'categories', 'os_categories']" removableSort
+      sortMode="multiple" paginator :rows="10" :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]">
 
       <template #header>
-        <div style="display: flex; justify-content: center">
+        <div style="display: flex; justify-content: center; ">
           <div style="width: 50%">
             <IconField>
               <InputIcon>
@@ -17,21 +18,21 @@
         </div>
       </template>
 
-      <Column frozen field="idx" header="Idx" />
-      <Column frozen field="user" header="User" style="min-width: 150px;" />
-      <Column frozen field="repo" header="Repo" style="min-width: 180px;" />
-      <Column frozen field="pkg" header="Package" style="min-width: 200px;" />
+      <Column frozen sortable field="idx" header="Idx" />
+      <Column frozen sortable field="user" header="User" style="min-width: 150px;" />
+      <Column frozen sortable field="repo" header="Repo" style="min-width: 180px;" />
+      <Column frozen sortable field="pkg" header="Package" style="min-width: 200px;" />
 
-      <Column field="version" header="Version" style="text-align: center;" />
-      <Column field="dependencies" header="Depen-dencies" style="text-align: center;" />
+      <Column sortable field="version" header="Version" style="text-align: center;" />
+      <Column sortable field="dependencies" header="Depen-dencies" style="text-align: center;" />
 
-      <Column field="testcases" header="TestCases" style="text-align: center;" />
+      <Column sortable field="testcases" header="TestCases" style="text-align: center;" />
 
-      <Column field="tests" header="Tests" style="text-align: center;" />
-      <Column field="examples" header="Examples" style="text-align: center;" />
-      <Column field="benches" header="Benches" style="text-align: center;" />
+      <Column sortable field="tests" header="Tests" style="text-align: center;" />
+      <Column sortable field="examples" header="Examples" style="text-align: center;" />
+      <Column sortable field="benches" header="Benches" style="text-align: center;" />
 
-      <Column field="categories" header="Categories" style="min-width: 210px;">
+      <Column sortable field="categories" header="Categories" style="min-width: 210px;">
         <template #body="{ data: { categories } }">
           <div v-for="tag of categories">
             <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
@@ -39,7 +40,7 @@
         </template>
       </Column>
 
-      <Column field="os_categories" header="OS Categories">
+      <Column sortable field="os_categories" header="OS Categories">
         <template #body="{ data: { os_categories } }">
           <div v-for="tag of os_categories">
             <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
@@ -49,7 +50,7 @@
 
       <Column field="description" header="Description" style="min-width: 400px;" />
 
-      <Column field="author" header="Author" style="min-width: 400px;">
+      <Column sortable field="author" header="Author" style="min-width: 400px;">
         <template #body="{ data: { author } }">
           <div v-for="tag of author">
             <Tag severity="info" :value="tag" style="margin-bottom: 5px;"></Tag>

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -119,12 +119,10 @@ const summaryColumns = [
 ];
 
 const summaryTable = computed(() => {
-  let idx = 0;
-  return summaries.value.map(val => {
+  const value = summaries.value.map(val => {
     return Object.entries(val.pkgs).map(([name, pkg]) => {
-      idx += 1;
       return {
-        idx,
+        idx: 0,
         user: val.user,
         repo: val.repo,
         pkg: name,
@@ -141,6 +139,32 @@ const summaryTable = computed(() => {
       }
     })
   }).flat();
+
+  return value.sort((a, b) => {
+    const a_test = a.testcases ?? 0;
+    const b_test = b.testcases ?? 0;
+    if (a_test < b_test) {
+      return 1;
+    } else if (a_test > b_test) {
+      return -1;
+    } else if (a.user < b.user) {
+      return -1;
+    } else if (a.user > b.user) {
+      return 1;
+    } else if (a.repo < b.repo) {
+      return -1;
+    } else if (a.repo > b.repo) {
+      return 1;
+    } else if (a.pkg < b.pkg) {
+      return -1;
+    } else if (a.pkg > b.pkg) {
+      return 1;
+    }
+    return 0;
+  }).map((val, idx) => {
+    val.idx = idx + 1;
+    return val;
+  });
 });
 
 const dialogShow = ref(false);

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -1,13 +1,22 @@
 <template>
   <div>
     <DataTable :value="summaryTable" tableStyle="min-width: 50rem; margin: 10px 10px;" scrollable scrollHeight="800px"
-      showGridlines selectionMode="single" v-model:selection="selectedPkg">
-      <!-- <template #header> -->
-      <!--     <div style="text-align:left"> -->
-      <!--         <MultiSelect :modelValue="selectedColumns" :options="columns" optionLabel="header" @update:modelValue="onToggle" -->
-      <!--             display="chip" placeholder="Select Columns" /> -->
-      <!--     </div> -->
-      <!-- </template> -->
+      showGridlines selectionMode="single" v-model:selection="selectedPkg" v-model:filters="filters"
+      :globalFilterFields="['user', 'repo', 'pkg', 'description', 'categories', 'os_categories']">
+
+      <template #header>
+        <div style="display: flex; justify-content: center">
+          <div style="width: 50%">
+            <IconField>
+              <InputIcon>
+                <i class="pi pi-search" />
+              </InputIcon>
+              <InputText style="width: 100%" v-model="filters['global'].value" placeholder="Global Search" />
+            </IconField>
+          </div>
+        </div>
+      </template>
+
       <Column frozen field="idx" header="Idx" />
       <Column frozen field="user" header="User" style="min-width: 150px;" />
       <Column frozen field="repo" header="Repo" style="min-width: 180px;" />
@@ -92,6 +101,12 @@
 
 <script setup lang="ts">
 import type { Pkg, PkgInfo, Test } from '~/shared/info';
+import { FilterMatchMode } from '@primevue/core/api';
+
+// interactive filter/search inputs
+const filters = ref<any>({
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+});
 
 const summaries = ref<PkgInfo[]>([]);
 
@@ -166,6 +181,8 @@ const summaryTable = computed(() => {
     return val;
   });
 });
+
+
 
 const dialogShow = ref(false);
 const dialogHeader = ref<{ repo: string, repo_url: string, pkg_name: string, pkg: Pkg } | null>();

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -1,59 +1,67 @@
 <template>
-  <!-- <TargetTable :data="summaryTable" :dataColumns="summaryColumns" :rowSelect="() => { }" /> -->
-  <DataTable :value="summaryTable" tableStyle="min-width: 50rem; margin: 10px 10px;" scrollable scrollHeight="800px"
-    showGridlines>
-    <!-- <template #header> -->
-    <!--     <div style="text-align:left"> -->
-    <!--         <MultiSelect :modelValue="selectedColumns" :options="columns" optionLabel="header" @update:modelValue="onToggle" -->
-    <!--             display="chip" placeholder="Select Columns" /> -->
-    <!--     </div> -->
-    <!-- </template> -->
-    <Column frozen field="idx" header="Idx" />
-    <Column frozen field="user" header="User" style="min-width: 150px;" />
-    <Column frozen field="repo" header="Repo" style="min-width: 180px;" />
-    <Column frozen field="pkg" header="Package" style="min-width: 200px;" />
+  <div>
+    <DataTable :value="summaryTable" tableStyle="min-width: 50rem; margin: 10px 10px;" scrollable scrollHeight="800px"
+      showGridlines selectionMode="single" v-model:selection="selectedPkg" @row-click="rowClick">
+      <!-- <template #header> -->
+      <!--     <div style="text-align:left"> -->
+      <!--         <MultiSelect :modelValue="selectedColumns" :options="columns" optionLabel="header" @update:modelValue="onToggle" -->
+      <!--             display="chip" placeholder="Select Columns" /> -->
+      <!--     </div> -->
+      <!-- </template> -->
+      <Column frozen field="idx" header="Idx" />
+      <Column frozen field="user" header="User" style="min-width: 150px;" />
+      <Column frozen field="repo" header="Repo" style="min-width: 180px;" />
+      <Column frozen field="pkg" header="Package" style="min-width: 200px;" />
 
-    <Column field="version" header="Version" style="text-align: center;" />
-    <Column field="dependencies" header="Depen-dencies" style="text-align: center;" />
-    <Column field="testcases" header="TestCases" style="text-align: center;" />
-    <Column field="tests" header="Tests" style="text-align: center;" />
-    <Column field="examples" header="Examples" style="text-align: center;" />
-    <Column field="benches" header="Benches" style="text-align: center;" />
-    <!-- <Column v-for="(col, index) of summaryColumns" :field="col.field" :header="col.header" -->
-    <!--   :key="col.field + '_' + index" style="text-align: center;"> -->
-    <!-- </Column> -->
+      <Column field="version" header="Version" style="text-align: center;" />
+      <Column field="dependencies" header="Depen-dencies" style="text-align: center;" />
 
-    <Column field="categories" header="Categories" style="min-width: 210px;">
-      <template #body="{ data: { categories } }">
-        <div v-for="tag of categories">
-          <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
-        </div>
-      </template>
-    </Column>
+      <Column field="testcases" header="TestCases" style="text-align: center;">
+        <template #body="{ data }">
+          <div style="color: var(--p-indigo-400); font-weight: bold; text-decoration: underline;"
+            @click="() => handleClick(data.user, data.repo, data.pkg, data.testcases)">{{ data.testcases }}
+          </div>
+        </template>
+      </Column>
 
-    <Column field="os_categories" header="OS Categories">
-      <template #body="{ data: { os_categories } }">
-        <div v-for="tag of os_categories">
-          <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
-        </div>
-      </template>
-    </Column>
+      <Column field="tests" header="Tests" style="text-align: center;" />
+      <Column field="examples" header="Examples" style="text-align: center;" />
+      <Column field="benches" header="Benches" style="text-align: center;" />
 
-    <Column frozen field="description" header="Description" style="min-width: 400px;" />
+      <Column field="categories" header="Categories" style="min-width: 210px;">
+        <template #body="{ data: { categories } }">
+          <div v-for="tag of categories">
+            <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
+          </div>
+        </template>
+      </Column>
 
-    <Column field="author" header="Author" style="min-width: 400px;">
-      <template #body="{ data: { author } }">
-        <div v-for="tag of author">
-          <Tag severity="info" :value="tag" style="margin-bottom: 5px;"></Tag>
-        </div>
-      </template>
-    </Column>
+      <Column field="os_categories" header="OS Categories">
+        <template #body="{ data: { os_categories } }">
+          <div v-for="tag of os_categories">
+            <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
+          </div>
+        </template>
+      </Column>
 
+      <Column field="description" header="Description" style="min-width: 400px;" />
 
-  </DataTable>
+      <Column field="author" header="Author" style="min-width: 400px;">
+        <template #body="{ data: { author } }">
+          <div v-for="tag of author">
+            <Tag severity="info" :value="tag" style="margin-bottom: 5px;"></Tag>
+          </div>
+        </template>
+      </Column>
+
+    </DataTable>
+
+    <Dialog v-model:visible="showTestCases" modal header="Test Cases"></Dialog>
+  </div>
 </template>
 
 <script setup lang="ts">
+import type { DataTableRowClickEvent } from 'primevue/datatable';
 import type { PkgInfo } from '~/shared/info';
 
 const summaries = ref<PkgInfo[]>([]);
@@ -92,7 +100,7 @@ const summaryTable = computed(() => {
         repo: val.repo,
         pkg: name,
         version: pkg.version,
-        dependencies: pkg.dependencies,
+        dependencies: pkg.dependencies || null,
         testcases: pkg.testcases ? pkg.testcases.pkg_tests_count : null,
         tests: pkg.tests || null,
         examples: pkg.examples || null,
@@ -106,5 +114,23 @@ const summaryTable = computed(() => {
   }).flat();
 });
 
+type SelectedRow = { user: string, repo: string, pkg: string };
+const selectedPkg = ref<SelectedRow | null>(null);
+// watch(selectedPkg, (val) => console.log(val));
 
+const showTestCases = ref(false);
+
+function handleClick(user: string, repo: string, pkg: string, n: number) {
+  if (n === 0) { return; }
+
+  console.log(user, repo, pkg);
+  showTestCases.value = true;
+}
+
+function rowClick(event: DataTableRowClickEvent) {
+  const data = event.data;
+  if (data.testcases === 0) { return; }
+  // console.log(event);
+
+}
 </script>

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -1,0 +1,110 @@
+<template>
+  <!-- <TargetTable :data="summaryTable" :dataColumns="summaryColumns" :rowSelect="() => { }" /> -->
+  <DataTable :value="summaryTable" tableStyle="min-width: 50rem; margin: 10px 10px;" scrollable scrollHeight="800px"
+    showGridlines>
+    <!-- <template #header> -->
+    <!--     <div style="text-align:left"> -->
+    <!--         <MultiSelect :modelValue="selectedColumns" :options="columns" optionLabel="header" @update:modelValue="onToggle" -->
+    <!--             display="chip" placeholder="Select Columns" /> -->
+    <!--     </div> -->
+    <!-- </template> -->
+    <Column frozen field="idx" header="Idx" />
+    <Column frozen field="user" header="User" style="min-width: 150px;" />
+    <Column frozen field="repo" header="Repo" style="min-width: 180px;" />
+    <Column frozen field="pkg" header="Package" style="min-width: 200px;" />
+
+    <Column field="version" header="Version" style="text-align: center;" />
+    <Column field="dependencies" header="Depen-dencies" style="text-align: center;" />
+    <Column field="testcases" header="TestCases" style="text-align: center;" />
+    <Column field="tests" header="Tests" style="text-align: center;" />
+    <Column field="examples" header="Examples" style="text-align: center;" />
+    <Column field="benches" header="Benches" style="text-align: center;" />
+    <!-- <Column v-for="(col, index) of summaryColumns" :field="col.field" :header="col.header" -->
+    <!--   :key="col.field + '_' + index" style="text-align: center;"> -->
+    <!-- </Column> -->
+
+    <Column field="categories" header="Categories" style="min-width: 210px;">
+      <template #body="{ data: { categories } }">
+        <div v-for="tag of categories">
+          <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
+        </div>
+      </template>
+    </Column>
+
+    <Column field="os_categories" header="OS Categories">
+      <template #body="{ data: { os_categories } }">
+        <div v-for="tag of os_categories">
+          <Tag severity="warn" :value="tag" style="margin-bottom: 5px;"></Tag>
+        </div>
+      </template>
+    </Column>
+
+    <Column frozen field="description" header="Description" style="min-width: 400px;" />
+
+    <Column field="author" header="Author" style="min-width: 400px;">
+      <template #body="{ data: { author } }">
+        <div v-for="tag of author">
+          <Tag severity="info" :value="tag" style="margin-bottom: 5px;"></Tag>
+        </div>
+      </template>
+    </Column>
+
+
+  </DataTable>
+</template>
+
+<script setup lang="ts">
+import type { PkgInfo } from '~/shared/info';
+
+const summaries = ref<PkgInfo[]>([]);
+
+githubFetch<PkgInfo[]>({
+  path: "plugin/cargo/info/summaries.json"
+}).then(val => {
+  summaries.value = val;
+});
+
+const summaryColumns = [
+  // { field: "idx", header: "Idx" },
+  // { field: "user", header: "User" },
+  // { field: "repo", header: "Repo" },
+  // { field: "pkg", header: "Package" },
+  { field: "version", header: "Version" },
+  { field: "dependencies", header: "Depen-dencies" },
+  { field: "testcases", header: "TestCases" },
+  { field: "tests", header: "Tests" },
+  { field: "examples", header: "Examples" },
+  { field: "benches", header: "Benches" },
+  // { field: "author", header: "Author" },
+  // { field: "description", header: "Description" },
+  // { field: "categories", header: "Categories" },
+  // { field: "os_categories", header: "OS Categories" },
+];
+
+const summaryTable = computed(() => {
+  let idx = 0;
+  return summaries.value.map(val => {
+    return Object.entries(val.pkgs).map(([name, pkg]) => {
+      idx += 1;
+      return {
+        idx,
+        user: val.user,
+        repo: val.repo,
+        pkg: name,
+        version: pkg.version,
+        dependencies: pkg.dependencies,
+        testcases: pkg.testcases ? pkg.testcases.pkg_tests_count : null,
+        tests: pkg.tests || null,
+        examples: pkg.examples || null,
+        benches: pkg.benches || null,
+        author: pkg.author.length === 0 ? null : pkg.author,
+        description: pkg.description,
+        categories: pkg.categories.length === 0 ? null : pkg.categories,
+        os_categories: pkg.os_categories.length === 0 ? null : pkg.os_categories,
+      }
+    })
+  }).flat();
+});
+
+
+</script>

--- a/os-checks/shared/info.ts
+++ b/os-checks/shared/info.ts
@@ -1,0 +1,34 @@
+export type PkgInfo = {
+  user: string,
+  repo: string,
+  pkgs: { [key: string]: Pkg }
+}
+
+export type Pkg = {
+  version: string,
+  dependencies: number,
+  lib: boolean,
+  bin: boolean,
+  testcases: TestCases | null,
+  tests: number,
+  examples: number,
+  benches: number,
+  author: string[]
+  description: string[],
+  categories: string[]
+  os_categories: string[],
+}
+
+export type TestCases = {
+  tests: Test[],
+  pkg_tests_count: number,
+  workspace_tests_count: number,
+}
+
+export type Test = {
+  id: string,
+  kind: string,
+  binary_name: string,
+  binary_path: string,
+  testcases: string[]
+}


### PR DESCRIPTION
支持文本、 categories、os_categories 和 authors 筛选，以及它们的联合筛选来查询 Packages；单击行显示测例信息。

https://github.com/user-attachments/assets/7e1ab862-2343-411e-8092-c4e4730fc35e

