### PR TITLE
feat: info 筛选条件与 URL 查询参数联动（即路由查询）

### DIFF
--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -298,25 +298,22 @@ const kinds = computed(() => {
   return arr;
 });
 const selectedCategories = ref<string[]>([]);
-const selectedOSCategories = ref<string[]>([]);
 const selectedKeywords = ref<string[]>([]);
 const selectedAuthors = ref<string[]>([]);
 const selectedKinds = ref<string[]>([]);
 watchEffect(() => {
   const cat = selectedCategories.value;
-  const os_cat = selectedOSCategories.value;
   const keywords = selectedKeywords.value;
   const au = selectedAuthors.value;
   const ks = selectedKinds.value;
 
   const is_empty_cat = cat.length === 0;
-  const is_empty_os_cat = os_cat.length === 0;
   const is_empty_keywords = keywords.length === 0;
   const is_empty_au = au.length === 0;
   const is_empty_k = ks.length === 0;
 
   // reset
-  if (is_empty_cat && is_empty_os_cat && is_empty_keywords && is_empty_au && is_empty_k) {
+  if (is_empty_cat &&  is_empty_keywords && is_empty_au && is_empty_k) {
     data.value = summaryTable.value;
     return;
   }

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -313,7 +313,7 @@ watchEffect(() => {
   const is_empty_k = ks.length === 0;
 
   // reset
-  if (is_empty_cat &&  is_empty_keywords && is_empty_au && is_empty_k) {
+  if (is_empty_cat && is_empty_keywords && is_empty_au && is_empty_k) {
     data.value = summaryTable.value;
     return;
   }
@@ -389,6 +389,39 @@ onMounted(() => {
   });
 });
 
+const route = useRoute();
+function updateFilter(query: {
+  categories?: string,
+  keywords?: string,
+  authors?: string,
+  kind?: string,
+  text?: string,
+}) {
+  if (query.categories) { selectedCategories.value = query.categories.split(","); }
+  if (query.keywords) { selectedKeywords.value = query.keywords.split(","); }
+  if (query.authors) { selectedAuthors.value = query.authors.split(","); }
+
+  if (query.kind) {
+    const filter = new Set([
+      "Lib", "Bin", "TestCases", "Tests", "Examples", "Benches"
+    ]);
+    selectedKinds.value = query.kind.split(",").filter(k => filter.has(k));
+  }
+
+  if (query.text) {
+    filters.value.global.value = decodeURIComponent(query.text);
+  }
+}
+updateFilter(route.query);
+// watch(() => route.query, updateFilter);
+
+// const router = useRouter();
+// clear query when the page is loaded
+// if (Object.keys(route.query).length !== 0) {
+//   router.push({ path: route.path });
+// }
+
+useHead({ title: 'Package Information' });
 </script>
 
 <style lang="css">

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -400,15 +400,15 @@ function updateFilter(query: {
   kinds?: string,
   text?: string,
 }) {
-  if (query.categories) { selected.categories = query.categories.split(","); }
-  if (query.keywords) { selected.keywords = query.keywords.split(","); }
-  if (query.authors) { selected.authors = query.authors.split(","); }
+  if (query.categories) { selected.categories = decodeURIComponent(query.categories).split(","); }
+  if (query.keywords) { selected.keywords = decodeURIComponent(query.keywords).split(","); }
+  if (query.authors) { selected.authors = decodeURIComponent(query.authors).split(","); }
 
   if (query.kinds) {
     const filter = new Set([
       "Lib", "Bin", "TestCases", "Tests", "Examples", "Benches"
     ]);
-    selected.kinds = query.kinds.split(",").filter(k => filter.has(k));
+    selected.kinds = decodeURIComponent(query.kinds).split(",").filter(k => filter.has(k));
   }
 
   if (query.text) {
@@ -418,7 +418,28 @@ function updateFilter(query: {
 updateFilter(route.query);
 // watch(() => route.query, updateFilter);
 
-// const router = useRouter();
+const router = useRouter();
+watch(selected, (sel) => {
+  let query: any = {};
+  if (sel.categories.length !== 0) {
+    query.categories = encodeURIComponent(sel.categories.join(","));
+  }
+  if (sel.keywords.length !== 0) {
+    query.keywords = encodeURIComponent(sel.keywords.join(","));
+  }
+  if (sel.authors.length !== 0) {
+    // FIXME: what if author string contains `,`
+    query.authors = encodeURIComponent(sel.authors.join(","));
+  }
+  if (sel.kinds.length !== 0) {
+    query.kinds = encodeURIComponent(sel.kinds.join(","));
+  }
+  if (sel.text.global.value) {
+    query.text = encodeURIComponent(sel.text.global.value);
+  }
+
+  router.push({ path: route.path, query });
+});
 // clear query when the page is loaded
 // if (Object.keys(route.query).length !== 0) {
 //   router.push({ path: route.path });

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -18,7 +18,7 @@
               placeholder="Select Authors" />
 
             <MultiSelect v-model="selectedKinds" display="chip" :options="kinds" filter :maxSelectedLabels="4"
-              placeholder="Select Crate Kind" />
+              placeholder="Select Crate Kinds" />
           </div>
 
           <div>
@@ -394,18 +394,18 @@ function updateFilter(query: {
   categories?: string,
   keywords?: string,
   authors?: string,
-  kind?: string,
+  kinds?: string,
   text?: string,
 }) {
   if (query.categories) { selectedCategories.value = query.categories.split(","); }
   if (query.keywords) { selectedKeywords.value = query.keywords.split(","); }
   if (query.authors) { selectedAuthors.value = query.authors.split(","); }
 
-  if (query.kind) {
+  if (query.kinds) {
     const filter = new Set([
       "Lib", "Bin", "TestCases", "Tests", "Examples", "Benches"
     ]);
-    selectedKinds.value = query.kind.split(",").filter(k => filter.has(k));
+    selectedKinds.value = query.kinds.split(",").filter(k => filter.has(k));
   }
 
   if (query.text) {

--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -1,23 +1,23 @@
 <template>
   <div>
     <DataTable :value="data" tableStyle="min-width: 50rem; margin: 0 5px 0 0;" scrollable :scrollHeight="tableHeight"
-      showGridlines selectionMode="single" v-model:selection="selectedPkg" v-model:filters="filters"
+      showGridlines selectionMode="single" v-model:selection="selectedPkg" v-model:filters="selected.text"
       :globalFilterFields="['user', 'repo', 'pkg', 'description', 'categories']" removableSort sortMode="multiple"
       paginator :rows="10" :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]">
 
       <template #header>
         <div style="display: flex; justify-content: space-between;">
           <div style="display: flex; gap: 20px;">
-            <MultiSelect v-model="selectedCategories" display="chip" :options="categories" filter :maxSelectedLabels="4"
-              placeholder="Select Categories" />
+            <MultiSelect v-model="selected.categories" display="chip" :options="categories" filter
+              :maxSelectedLabels="4" placeholder="Select Categories" />
 
-            <MultiSelect v-model="selectedKeywords" display="chip" :options="keywords" filter :maxSelectedLabels="4"
+            <MultiSelect v-model="selected.keywords" display="chip" :options="keywords" filter :maxSelectedLabels="4"
               placeholder="Select Keywords" />
 
-            <MultiSelect v-model="selectedAuthors" display="chip" :options="authors" filter :maxSelectedLabels="4"
+            <MultiSelect v-model="selected.authors" display="chip" :options="authors" filter :maxSelectedLabels="4"
               placeholder="Select Authors" />
 
-            <MultiSelect v-model="selectedKinds" display="chip" :options="kinds" filter :maxSelectedLabels="4"
+            <MultiSelect v-model="selected.kinds" display="chip" :options="kinds" filter :maxSelectedLabels="4"
               placeholder="Select Crate Kinds" />
           </div>
 
@@ -26,7 +26,7 @@
               <InputIcon>
                 <i class="pi pi-search" />
               </InputIcon>
-              <InputText style="width: 100%" v-model="filters['global'].value"
+              <InputText style="width: 100%" v-model="selected.text['global'].value"
                 placeholder="Search in all text columns" />
             </IconField>
           </div>
@@ -178,11 +178,6 @@ import { FilterMatchMode } from '@primevue/core/api';
 
 const { color } = storeToRefs(useColorStore());
 
-// interactive filter/search inputs
-const filters = ref<any>({
-  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-});
-
 const summaries = ref<PkgInfo[]>([]);
 
 githubFetch<PkgInfo[]>({
@@ -297,15 +292,23 @@ const kinds = computed(() => {
   if (is_benches) { arr.push("Benches"); }
   return arr;
 });
-const selectedCategories = ref<string[]>([]);
-const selectedKeywords = ref<string[]>([]);
-const selectedAuthors = ref<string[]>([]);
-const selectedKinds = ref<string[]>([]);
+
+const selected = reactive<{
+  categories: string[],
+  keywords: string[],
+  authors: string[],
+  kinds: string[],
+  text: any
+}>({
+  categories: [], keywords: [], authors: [], kinds: [],
+  // interactive filter/search inputs
+  text: { global: { value: null, matchMode: FilterMatchMode.CONTAINS }, }
+});
 watchEffect(() => {
-  const cat = selectedCategories.value;
-  const keywords = selectedKeywords.value;
-  const au = selectedAuthors.value;
-  const ks = selectedKinds.value;
+  const cat = selected.categories;
+  const keywords = selected.keywords;
+  const au = selected.authors;
+  const ks = selected.kinds;
 
   const is_empty_cat = cat.length === 0;
   const is_empty_keywords = keywords.length === 0;
@@ -397,19 +400,19 @@ function updateFilter(query: {
   kinds?: string,
   text?: string,
 }) {
-  if (query.categories) { selectedCategories.value = query.categories.split(","); }
-  if (query.keywords) { selectedKeywords.value = query.keywords.split(","); }
-  if (query.authors) { selectedAuthors.value = query.authors.split(","); }
+  if (query.categories) { selected.categories = query.categories.split(","); }
+  if (query.keywords) { selected.keywords = query.keywords.split(","); }
+  if (query.authors) { selected.authors = query.authors.split(","); }
 
   if (query.kinds) {
     const filter = new Set([
       "Lib", "Bin", "TestCases", "Tests", "Examples", "Benches"
     ]);
-    selectedKinds.value = query.kinds.split(",").filter(k => filter.has(k));
+    selected.kinds = query.kinds.split(",").filter(k => filter.has(k));
   }
 
   if (query.text) {
-    filters.value.global.value = decodeURIComponent(query.text);
+    selected.text.global.value = decodeURIComponent(query.text);
   }
 }
 updateFilter(route.query);


### PR DESCRIPTION
close https://github.com/os-checker/os-checker.github.io/issues/105

实现这个 PR 之后
* 当更新筛选条件时，浏览器的地址栏的 URL query params 会自动更新，从而使用者可以分享这个 URL 链接；
* 获得上述 URL 链接的访问者，则无需重复输入相同的查询条件，来获得使用者所看到的查询结果。

该 PR 实现的代码思路，可拓展至实现  target 页面 ( https://github.com/os-checker/os-checker.github.io/issues/84 ) 或者其他页面的路由查询。