### PR TITLE
feat: repo 页面重命名为 repos；添加筛选条件并支持路由参数查询

### DIFF
--- a/os-checks/components/TopBar.vue
+++ b/os-checks/components/TopBar.vue
@@ -27,8 +27,8 @@
         <Button title="Package Infomation" icon="pi pi-microchip" />
       </NuxtLink>
 
-      <NuxtLink to="/repo">
-        <Button title="Repository Infomation" icon="pi pi-warehouse" />
+      <NuxtLink to="/repos">
+        <Button title="Repositories Infomation" icon="pi pi-warehouse" />
       </NuxtLink>
 
     </div>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -290,6 +290,43 @@ watch(selected, (sel) => {
   data.value = new_data;
 });
 
+// route query
+const route = useRoute();
+function updateFilter(query: {
+  licenses?: string,
+  topics?: string,
+  columns?: string,
+  text?: string,
+}) {
+  if (query.licenses) { selected.licenses = decodeURIComponent(query.licenses).split(","); }
+  if (query.topics) { selected.topics = decodeURIComponent(query.topics).split(","); }
+  if (query.columns) { selected.columns = decodeURIComponent(query.columns).split(","); }
+
+  if (query.text) {
+    selected.text.global.value = decodeURIComponent(query.text);
+  }
+}
+updateFilter(route.query);
+
+const router = useRouter();
+watch(selected, (sel) => {
+  let query: any = {};
+  if (sel.licenses.length !== 0) {
+    query.licenses = encodeURIComponent(sel.licenses.join(","));
+  }
+  if (sel.topics.length !== 0) {
+    query.topics = encodeURIComponent(sel.topics.join(","));
+  }
+  if (sel.columns.length !== 0) {
+    query.columns = encodeURIComponent(sel.columns.join(","));
+  }
+  if (sel.text.global.value) {
+    query.text = encodeURIComponent(sel.text.global.value);
+  }
+
+  router.push({ path: route.path, query });
+});
+
 </script>
 
 <style lang="css" scoped>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -1,8 +1,22 @@
 <template>
   <div style="margin: 0 8px">
+    <div class="filter">
+      <div style="display: flex; gap: 10px;">
+      </div>
+
+      <div>
+        <IconField>
+          <InputIcon> <i class="pi pi-search" /> </InputIcon>
+          <InputText style="width: 180px" v-model="selected.text['global'].value" placeholder="Search" />
+        </IconField>
+      </div>
+
+    </div>
+
     <DataTable :value="repo" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single"
       v-model:selection="selectedRepo" removableSort sortMode="multiple" paginator :rows="10"
-      :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]">
+      :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]" v-model:filters="selected.text"
+      :globalFilterFields="['user', 'repo', 'description', 'license', 'topics']">
 
       <Column frozen field="idx" header="Idx" />
       <Column frozen sortable field="user" header="User" style="min-width: 150px;" />
@@ -81,6 +95,7 @@
 </template>
 
 <script setup lang="ts">
+import { FilterMatchMode } from '@primevue/core/api';
 import type { Output } from '~/shared/repo';
 
 useHead({ title: 'Repository Information' });
@@ -192,4 +207,16 @@ function formatBytes(bytes: number, decimals = 0) {
 }
 
 const selectedRepo = ref();
+
+const selected = reactive({
+  text: { global: { value: null, matchMode: FilterMatchMode.CONTAINS }, },
+});
 </script>
+
+<style lang="css" scoped>
+.filter {
+  display: flex;
+  justify-content: space-between;
+  margin: 6px 18px;
+}
+</style>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -1,13 +1,8 @@
 <template>
   <div style="margin: 0 8px">
-    <!-- <DataTable :value="data" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single" -->
-    <!--   v-model:selection="selectedPkg" v-model:filters="selected.text" -->
-    <!--   :globalFilterFields="['user', 'repo', 'pkg', 'description', 'categories']" removableSort sortMode="multiple" -->
-    <!--   paginator :rows="10" :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]"> -->
-    <!---->
-    <!-- </DataTable> -->
-    <DataTable :value="repo" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single" removableSort
-      sortMode="multiple" paginator :rows="10" :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]">
+    <DataTable :value="repo" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single"
+      v-model:selection="selectedRepo" removableSort sortMode="multiple" paginator :rows="10"
+      :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]">
 
       <Column frozen field="idx" header="Idx" />
       <Column frozen sortable field="user" header="User" style="min-width: 150px;" />
@@ -185,9 +180,7 @@ const repo = computed<Repo[]>(() => {
 });
 
 function formatBytes(bytes: number, decimals = 0) {
-  if (bytes === 0) {
-    return '0 B';
-  }
+  if (bytes === 0) { return '0 B'; }
 
   const k = 1024; // 1KB = 1024 bytes
   const dm = decimals < 0 ? 0 : decimals; // 小数位数
@@ -197,4 +190,6 @@ function formatBytes(bytes: number, decimals = 0) {
 
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
+
+const selectedRepo = ref();
 </script>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -4,6 +4,9 @@
       <div style="display: flex; gap: 10px;">
         <MultiSelect v-model="selected.licenses" display="chip" :options="licenses" filter :maxSelectedLabels="4"
           placeholder="Select License" />
+
+        <MultiSelect v-model="selected.topics" display="chip" :options="topics" filter :maxSelectedLabels="4"
+          placeholder="Select Topics" />
       </div>
 
       <div>
@@ -214,12 +217,15 @@ function formatBytes(bytes: number, decimals = 0) {
 const selectedRepo = ref();
 
 const licenses = computed(() => [...new Set(repo.value.map(r => r.license))].sort());
+const topics = computed(() => [...new Set(repo.value.map(r => r.topics).flat())].sort());
 
 const selected = reactive<{
   licenses: string[],
+  topics: string[],
   text: any,
 }>({
   licenses: [],
+  topics: [],
   text: { global: { value: null, matchMode: FilterMatchMode.CONTAINS }, },
 });
 
@@ -229,6 +235,11 @@ watch(selected, (sel) => {
   // empty licenses means all licenses
   if (sel.licenses.length !== 0) {
     new_data = new_data.filter(val => sel.licenses.findIndex(x => x === val.license) !== -1);
+  }
+
+  if (sel.topics.length !== 0) {
+    const set = new Set(sel.topics);
+    new_data = new_data.filter(val => val.topics.findIndex(t => set.has(t)) !== -1);
   }
 
   data.value = new_data;

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -9,7 +9,7 @@
           placeholder="Select Topics" />
 
         <MultiSelect v-model="selected.columns" display="chip" :options="columns" filter :maxSelectedLabels="4"
-          placeholder="Select Columns" :showClear="true" />
+          placeholder="Select Columns" />
       </div>
 
       <div>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -2,6 +2,8 @@
   <div style="margin: 0 8px">
     <div class="filter">
       <div style="display: flex; gap: 10px;">
+        <MultiSelect v-model="selected.licenses" display="chip" :options="licenses" filter :maxSelectedLabels="4"
+          placeholder="Select License" />
       </div>
 
       <div>
@@ -13,7 +15,7 @@
 
     </div>
 
-    <DataTable :value="repo" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single"
+    <DataTable :value="data" scrollable :scrollHeight="tableHeight" showGridlines selectionMode="single"
       v-model:selection="selectedRepo" removableSort sortMode="multiple" paginator :rows="10"
       :rowsPerPageOptions="[5, 10, 20, 50, 100, 200, 1000]" v-model:filters="selected.text"
       :globalFilterFields="['user', 'repo', 'description', 'license', 'topics']">
@@ -194,6 +196,9 @@ const repo = computed<Repo[]>(() => {
   })
 });
 
+const data = ref<Repo[]>([]);
+watch(repo, (val) => data.value = val);
+
 function formatBytes(bytes: number, decimals = 0) {
   if (bytes === 0) { return '0 B'; }
 
@@ -208,9 +213,27 @@ function formatBytes(bytes: number, decimals = 0) {
 
 const selectedRepo = ref();
 
-const selected = reactive({
+const licenses = computed(() => [...new Set(repo.value.map(r => r.license))].sort());
+
+const selected = reactive<{
+  licenses: string[],
+  text: any,
+}>({
+  licenses: [],
   text: { global: { value: null, matchMode: FilterMatchMode.CONTAINS }, },
 });
+
+watch(selected, (sel) => {
+  let new_data = repo.value;
+
+  // empty licenses means all licenses
+  if (sel.licenses.length !== 0) {
+    new_data = new_data.filter(val => sel.licenses.findIndex(x => x === val.license) !== -1);
+  }
+
+  data.value = new_data;
+});
+
 </script>
 
 <style lang="css" scoped>

--- a/os-checks/pages/repo.vue
+++ b/os-checks/pages/repo.vue
@@ -7,6 +7,9 @@
 
         <MultiSelect v-model="selected.topics" display="chip" :options="topics" filter :maxSelectedLabels="4"
           placeholder="Select Topics" />
+
+        <MultiSelect v-model="selected.columns" display="chip" :options="columns" filter :maxSelectedLabels="4"
+          placeholder="Select Columns" :showClear="true" />
       </div>
 
       <div>
@@ -34,9 +37,9 @@
         </template>
       </Column>
 
-      <Column sortable field="license" header="License" :pt="ptColumnCenter" />
+      <Column v-if="C['License']" sortable field="license" header="License" :pt="ptColumnCenter" />
 
-      <Column sortable field="homepage" header="Home" :pt="ptColumnCenter">
+      <Column v-if="C['Home']" sortable field="homepage" header="Home" :pt="ptColumnCenter">
         <template #body="{ data }">
           <NuxtLink v-if="data.homepage" :to="data.homepage" target="_blank" class="nav-link">
             <!-- <Button icon="pi pi-external-link" link /> a bug when scrolling -->
@@ -45,7 +48,7 @@
         </template>
       </Column>
 
-      <Column sortable field="open_issues_count" header="Open Issues" :pt="ptColumnCenter">
+      <Column v-if="C['Open Issues']" sortable field="open_issues_count" header="Open Issues" :pt="ptColumnCenter">
         <template #body="{ data }">
           <NuxtLink v-if="data.issues" target="_blank" class="nav-link"
             :to="`https://github.com/${data.user}/${data.repo}/issues`">
@@ -54,14 +57,15 @@
         </template>
       </Column>
 
-      <Column sortable field="description" header="Description" style="max-width: 500px; min-width: 300px" />
-      <Column sortable field="created_at" header="Created" :pt="ptColumnCenter" />
-      <Column sortable field="pushed_at" header="Updated" :pt="ptColumnCenter" />
-      <Column sortable field="active_days" header="Active Days" :pt="ptColumnRight" />
-      <Column sortable field="contributions" header="Contri-butions" :pt="ptColumnRight" />
-      <Column sortable field="contributors" header="Contri-butors" :pt="ptColumnRight" />
+      <Column v-if="C['Description']" sortable field="description" header="Description"
+        style="max-width: 500px; min-width: 280px" />
+      <Column v-if="C['Created']" sortable field="created_at" header="Created" :pt="ptColumnCenter" />
+      <Column v-if="C['Updated']" sortable field="pushed_at" header="Updated" :pt="ptColumnCenter" />
+      <Column v-if="C['Active Days']" sortable field="active_days" header="Active Days" :pt="ptColumnRight" />
+      <Column v-if="C['Contri-butions']" sortable field="contributions" header="Contri-butions" :pt="ptColumnRight" />
+      <Column v-if="C['Contri-butors']" sortable field="contributors" header="Contri-butors" :pt="ptColumnRight" />
 
-      <Column sortable field="size" header="Size" :pt="ptColumnRight">
+      <Column v-if="C['Size']" sortable field="size" header="Size" :pt="ptColumnRight">
         <template #body="{ data }">
           <span :style="{ color: (data.size < 1024) ? color.grey : '' }">
             {{ formatBytes(data.size) }}
@@ -69,16 +73,16 @@
         </template>
       </Column>
 
-      <Column sortable field="default_branch" header="Default Branch" :pt="ptColumnCenter" />
-      <Column sortable field="fork" header="Is this Forked" :pt="ptColumnCenter" />
-      <Column sortable field="archived" header="Is this Archived" :pt="ptColumnCenter" />
+      <Column v-if="C['Default Branch']" sortable field="default_branch" header="Default Branch" :pt="ptColumnCenter" />
+      <Column v-if="C['Is This Forked']" sortable field="fork" header="Is This Forked" :pt="ptColumnCenter" />
+      <Column v-if="C['Is This Archived']" sortable field="archived" header="Is This Archived" :pt="ptColumnCenter" />
 
-      <Column sortable field="stargazers" header="Star-gazers" :pt="ptColumnRight" />
-      <Column sortable field="subscribers" header="Sub-scribers" :pt="ptColumnRight" />
-      <Column sortable field="forks" header="Forks" :pt="ptColumnRight" />
-      <Column sortable field="network" header="Net Work" :pt="ptColumnRight" />
+      <Column v-if="C['Star-gazers']" ortable field="stargazers" header="Star-gazers" :pt="ptColumnRight" />
+      <Column v-if="C['Sub-scribers']" ortable field="subscribers" header="Sub-scribers" :pt="ptColumnRight" />
+      <Column v-if="C['Forks']" ortable field="forks" header="Forks" :pt="ptColumnRight" />
+      <Column v-if="C['Net Work']" ortable field="network" header="Net Work" :pt="ptColumnRight" />
 
-      <Column sortable field="discussions" header="Discussions" :pt="ptColumnCenter">
+      <Column v-if="C['Discussions']" sortable field="discussions" header="Discussions" :pt="ptColumnCenter">
         <template #body="{ data }">
           <NuxtLink v-if="data.discussions" target="_blank" class="nav-link"
             :to="`https://github.com/${data.user}/${data.repo}/discussions`">
@@ -87,7 +91,7 @@
         </template>
       </Column>
 
-      <Column sortable field="topics" header="Topics" style="min-width: 180px;">
+      <Column v-if="C['Topics']" sortable field="topics" header="Topics" style="min-width: 180px;">
         <template #body="{ data: { topics } }">
           <div v-for="val of topics">
             <Tag severity="info" :value="val" style="margin-bottom: 5px;" />
@@ -219,13 +223,40 @@ const selectedRepo = ref();
 const licenses = computed(() => [...new Set(repo.value.map(r => r.license))].sort());
 const topics = computed(() => [...new Set(repo.value.map(r => r.topics).flat())].sort());
 
+const columns = ref([
+  "[Columns] Full", "[Columns] Default (Slimmed)", "License", "Home", "Open Issues", "Description", "Created", "Updated",
+  "Active Days", "Contri-butions", "Contri-butors", "Size", "Default Branch",
+  "Is This Forked", "Is This Archived", "Star-gazers", "Sub-scribers",
+  "Forks", "Net Work", "Discussions", "Topics"
+]);
+
+const C = reactive<{ [key: string]: boolean }>({
+  "License": false, "Home": false, "Open Issues": false, "Description": false, "Created": false, "Updated": false,
+  "Active Days": false, "Contri-butions": false, "Contri-butors": false, "Size": false, "Default Branch": false,
+  "Is This Forked": false, "Is This Archived": false, "Star-gazers": false, "Sub-scribers": false,
+  "Forks": false, "Net Work": false, "Discussions": false, "Topics": false
+});
+
+function setDefaultColumns() {
+  const set = new Set([
+    "License", "Home", "Description", "Updated",
+    "Active Days", "Contri-butions", "Contri-butors", "Size",
+  ]);
+  for (const col of Object.keys(C)) {
+    C[col] = set.has(col);
+  }
+}
+setDefaultColumns();
+
 const selected = reactive<{
   licenses: string[],
   topics: string[],
+  columns: string[],
   text: any,
 }>({
   licenses: [],
   topics: [],
+  columns: [],
   text: { global: { value: null, matchMode: FilterMatchMode.CONTAINS }, },
 });
 
@@ -240,6 +271,20 @@ watch(selected, (sel) => {
   if (sel.topics.length !== 0) {
     const set = new Set(sel.topics);
     new_data = new_data.filter(val => val.topics.findIndex(t => set.has(t)) !== -1);
+  }
+
+  if (sel.columns.length === 0 || sel.columns.findIndex(c => c === "[Columns] Default (Slimmed)") !== -1) {
+    setDefaultColumns();
+  } else if (sel.columns.findIndex(c => c === "[Columns] Full") !== -1) {
+    // display all columns 
+    for (const col of Object.keys(C)) {
+      C[col] = true;
+    }
+  } else {
+    const set = new Set(sel.columns);
+    for (const col of Object.keys(C)) {
+      C[col] = set.has(col);
+    }
   }
 
   data.value = new_data;

--- a/os-checks/pages/repos.vue
+++ b/os-checks/pages/repos.vue
@@ -107,7 +107,7 @@
 import { FilterMatchMode } from '@primevue/core/api';
 import type { Output } from '~/shared/repo';
 
-useHead({ title: 'Repository Information' });
+useHead({ title: 'Repositories Information' });
 
 const tableHeight = ref("800px");
 onMounted(() => {


### PR DESCRIPTION

https://github.com/user-attachments/assets/92fad475-a012-46ae-a777-7e6ed7e8c5b6

默认为精简列：
![截图_20241109203919](https://github.com/user-attachments/assets/88128300-e540-4cfa-88bb-371145ae3328)

通过筛选，展示全部列：
![截图_20241109203844](https://github.com/user-attachments/assets/e1f5a502-2400-473b-9e61-5fe83104a0e4)

筛选 License：
![截图_20241109203907](https://github.com/user-attachments/assets/92ed8c22-025b-4ee7-8276-5b01d87e5d98)
