### PR TITLE
feat(info): 增加 crates.io 发版次数和 os-checker 诊断结果数量

### DIFF
--- a/os-checks/pages/info.vue
+++ b/os-checks/pages/info.vue
@@ -52,6 +52,22 @@
       <Column sortable v-if="display.digits" field="lib" header="Lib" style="text-align: center;" />
       <Column sortable v-if="display.digits" field="bin" header="Bin" style="text-align: center;" />
       <Column sortable v-if="display.digits" field="dependencies" header="Depen-dencies" style="text-align: center;" />
+      <Column sortable field="release_count" header="crates.io Releases" style="text-align: center;">
+        <template #body="{ data }">
+          <NuxtLink :to="`https://crates.io/crates/${data.pkg}`" target="_blank" class="nav-link">
+            {{ data.release_count }}
+          </NuxtLink>
+        </template>
+      </Column>
+
+      <Column sortable field="diag_total_count" header="Diag-nostics" style="text-align: center;">
+        <template #body="{ data }">
+          <NuxtLink :to="`/${data.user}/${data.repo}`" target="_blank" class="nav-link">
+            {{ data.diag_total_count }}
+          </NuxtLink>
+        </template>
+      </Column>
+
 
       <Column sortable v-if="display.digits" field="testcases" header="Test Cases"
         style="text-align: center; font-weight: bold">
@@ -256,7 +272,9 @@ const summaryTable = computed<SummaryTable[]>(() => {
         documentation: pkg.documentation,
         readme: pkg.readme,
         homepage: pkg.homepage,
-        latest_doc: docs.value?.[val.user]?.[val.repo]?.[name] ?? null
+        latest_doc: docs.value?.[val.user]?.[val.repo]?.[name] ?? null,
+        diag_total_count: pkg.diag_total_count,
+        release_count: pkg.release_count,
       }
     })
   }).flat();
@@ -294,6 +312,7 @@ type SummaryTable = {
   tests: number | null; examples: number | null; benches: number | null; keywords: string[] | null;
   authors: string[] | null; description: string; categories: string[] | null;
   documentation: string | null; readme: string | null; homepage: string | null; latest_doc: string | null;
+  diag_total_count: number | null; release_count: number | null;
 };
 const data = ref<SummaryTable[]>([]);
 watch(summaryTable, (val) => data.value = val);

--- a/os-checks/shared/info.ts
+++ b/os-checks/shared/info.ts
@@ -21,6 +21,8 @@ export type Pkg = {
   keywords: string[],
   categories: string[]
   os_categories: string[],
+  diag_total_count: number | null,
+  release_count: number | null,
 }
 
 export type TestCases = {


### PR DESCRIPTION
![截图_20241119201924](https://github.com/user-attachments/assets/7bc04382-9e39-490a-b07d-c2f404696267)


注意：
* crates.io release 为空，表示该 package 未发布到 crates.io；
* 诊断数量为空，表示该 package 良好，未检查出错误。