### PR TITLE
Chore: Make testcase popup results unfold by default

### DIFF
--- a/os-checks/package-lock.json
+++ b/os-checks/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "nuxt-app",
       "hasInstallScript": true,
+      "license": "GPL-3.0 OR MulanPubL",
       "dependencies": {
         "@pinia/nuxt": "^0.10.1",
         "@primevue/themes": "^4.3.0",

--- a/os-checks/pages/testcases.vue
+++ b/os-checks/pages/testcases.vue
@@ -75,14 +75,14 @@
       {{ selectedTest!.miri_pass }}
     </div>
 
-    <Accordion value="0">
-      <AccordionPanel value="0" v-if="selectedTest?.test_error">
+    <Accordion value="0" multiple>
+      <AccordionPanel value="[0]" v-if="selectedTest?.test_error">
         <AccordionHeader>Test Error</AccordionHeader>
         <AccordionContent>
           <CodeBlock :snippets="selectedTest?.test_error ? [selectedTest.test_error] : []" />
         </AccordionContent>
       </AccordionPanel>
-      <AccordionPanel value="1" v-if="selectedTest?.miri_output">
+      <AccordionPanel value="[0]" v-if="selectedTest?.miri_output">
         <AccordionHeader>Miri Output</AccordionHeader>
         <AccordionContent>
           <CodeBlock :snippets="selectedTest?.miri_output ? [selectedTest.miri_output] : []" />

--- a/os-checks/pages/testcases.vue
+++ b/os-checks/pages/testcases.vue
@@ -75,14 +75,14 @@
       {{ selectedTest!.miri_pass }}
     </div>
 
-    <Accordion value="0" multiple>
-      <AccordionPanel value="[0]" v-if="selectedTest?.test_error">
+    <Accordion :value="[0, 1]" multiple>
+      <AccordionPanel :value="0" v-if="selectedTest?.test_error">
         <AccordionHeader>Test Error</AccordionHeader>
         <AccordionContent>
           <CodeBlock :snippets="selectedTest?.test_error ? [selectedTest.test_error] : []" />
         </AccordionContent>
       </AccordionPanel>
-      <AccordionPanel value="[0]" v-if="selectedTest?.miri_output">
+      <AccordionPanel :value="1" v-if="selectedTest?.miri_output">
         <AccordionHeader>Miri Output</AccordionHeader>
         <AccordionContent>
           <CodeBlock :snippets="selectedTest?.miri_output ? [selectedTest.miri_output] : []" />


### PR DESCRIPTION
Before: accordions in popup are folded by default
![](https://github.com/user-attachments/assets/2238048e-af0b-4d8f-8e98-27220d601059)


After: accordions in popup are unfolded by default
![unfold-testcase-results](https://github.com/user-attachments/assets/218dec83-adc8-4126-a9b3-4e9fba213c05)
